### PR TITLE
fix: Do not default to an empty path as public directory

### DIFF
--- a/quickemu/core/src/data/io.rs
+++ b/quickemu/core/src/data/io.rs
@@ -40,9 +40,16 @@ pub struct PublicDir(Option<PathBuf>);
 #[cfg(feature = "quickemu")]
 impl Default for PublicDir {
     fn default() -> Self {
-        let home = dirs::home_dir().unwrap_or_default();
-        let public = dirs::public_dir().unwrap_or_default();
-        Self((home != public).then_some(public))
+        let public_dir = dirs::public_dir();
+        let home_dir = dirs::home_dir();
+
+        // If the default public dir is the user's home directory, we won't share it with the guest
+        // for security reasons
+        if home_dir != public_dir {
+            Self(public_dir)
+        } else {
+            Self(None)
+        }
     }
 }
 


### PR DESCRIPTION
If the public directory couldn't be found, a bug was present where a default string would be used instead, due to the unwrap_or_default call before checking whether the home and public directories were the same.