### PR TITLE
fix: Match hexadecimal checksums without case sensitivity

### DIFF
--- a/quickget/core/src/instance.rs
+++ b/quickget/core/src/instance.rs
@@ -337,7 +337,7 @@ fn finalize_source(source: FinalSource, check_exists: bool) -> Result<PathBuf, D
             128 => format!("{:x}", sha2::Sha512::digest(bytes)),
             _ => unreachable!(),
         };
-        if computed_hash != checksum {
+        if !checksum.eq_ignore_ascii_case(&computed_hash) {
             return Err(DLError::FailedValidation(checksum, computed_hash));
         }
     }


### PR DESCRIPTION
- Closes #21 